### PR TITLE
adding composer file to make slippy installable through composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,12 @@
+{
+    "name": "seld/slippy",
+    "description": "HTML Slides Engine",
+    "license": "BSD-3-Clause",
+    "authors": [
+        {
+            "name": "Jordi Boggiano",
+            "email": "j.boggiano@seld.be",
+            "homepage": "http://seld.be"
+        }
+    ]
+}


### PR DESCRIPTION
would be helpful if we could install slippy through composer, even though its not reusable code in the current form.
