### PR TITLE
fix slides download from non-default port

### DIFF
--- a/src/index.php
+++ b/src/index.php
@@ -181,7 +181,7 @@ function convertImage($url)
     );
 
     if (PHP_SAPI !== 'cli') {
-        $baseUrl = ($_SERVER['SERVER_PORT'] === 443 ? 'https':'http') .'://'. $_SERVER['HTTP_HOST'].'/index.php';
+        $baseUrl = ($_SERVER['SERVER_PORT'] === 443 ? 'https':'http') .'://'. $_SERVER['HTTP_HOST'].':'.$_SERVER['SERVER_PORT'].'/index.php';
         $parts = parse_url($baseUrl);
         $imgUrl = $parts['scheme'].'://'.$parts['host'];
         if ($url{0} !== '/') {


### PR DESCRIPTION
i just tried exporting my slides and found that when running on a non-default port, the link is created wrongly. this fixes it (although not in my situation, i was using php -S which is single threaded and simply blocks the download because the server is already busy at that point... if i would have found an easy check to know if we run inside the built-in webserver i would have added a check and a warning message, but did not find quickly.). the right solution is to run index.php on the cli.